### PR TITLE
This should fix the session_key_expires bug.

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -1290,7 +1290,10 @@ class Facebook(object):
             self.added = True
 
         if params.get('expires'):
-            self.session_key_expires = int(params['expires'])
+            try:
+                self.session_key_expires = int(params['expires'])
+            except ValueError:
+                pass
 
         if 'locale' in params:
             self.locale = params['locale']
@@ -1368,8 +1371,8 @@ class Facebook(object):
             return None
 
         prefix = api_key + "_"
-       
-        params = {} 
+
+        params = {}
         vals = ''
         for k in sorted(cookies):
             if k.startswith(prefix):
@@ -1377,7 +1380,7 @@ class Facebook(object):
                 value = cookies[k]
                 params[key] = value
                 vals += '%s=%s' % (key, value)
-                
+
         hasher = hashlib.md5(vals)
 
         hasher.update(self.secret_key)


### PR DESCRIPTION
Added a try/except block around the casting of 'expires' to an int since it often comes back as the string 'None'.
